### PR TITLE
[WIP] Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 Gemfile.lock
 .DS_Store
+.jekyll-metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.4.1
+
+# https://nodejs.org/en/download/package-manager/
+
+RUN apt-get update && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y nodejs
+
+WORKDIR /

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,13 @@
 title: Open Design Kit
-exclude: [README.md, Gemfile, Gemfile.lock, CNAME, params.json]
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - CNAME
+  - params.json
+  - Dockerfile
+  - 'docker-*.yml'
+  - '*.sh'
 collections:
     methods:
         output: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/odk
+      - node-modules:/odk/node_modules/
+      - root:/root/
+      - bundle:/usr/local/bundle/
+    environment:
+      - LANG=C.UTF-8
+      - LANGUAGE=C.UTF-8
+      - LC_ALL=C.UTF-8
+    working_dir: /odk
+    command: jekyll serve --force_polling --H 0.0.0.0 -P 4000 --incremental
+    ports:
+      - 4000:4000
+    stop_signal: SIGKILL
+volumes:
+  node-modules:
+  root:
+  bundle:

--- a/docker-update.sh
+++ b/docker-update.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+set -e
+
+docker-compose build
+docker-compose run --rm app bash update.sh

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -e
+
+if ! which bundler > /dev/null; then
+  gem install bundler
+fi
+
+bundle install


### PR DESCRIPTION
This adds support for using Docker for development, so that users don't have to deal with installing Ruby 2.3+ and Node if they don't want to.

To do:
- [ ] Add documentation. (Also include docs for non-Docker setup to address #268.)
