### PR TITLE
Github Action for Link Checking

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,10 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,3 +8,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,8 @@
+{
+    "replacementPatterns" : [
+        {
+            "pattern": "^/",
+            "replacement" : "http://opendesignkit.org/"
+        }
+    ]
+}

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -4,5 +4,10 @@
             "pattern": "^/",
             "replacement" : "http://opendesignkit.org/"
         }
+    ],
+    "ignorePatterns" : [
+        {
+            "pattern" : "http://localhost"
+        }
     ]
 }


### PR DESCRIPTION
Added an action and appropriate config for a GitHub action that will audit the .md files for broken links. It ignores "localhost" and checks relative links against http://opendesignkit.org. It doesn't solve all the broken links but helps with #300.